### PR TITLE
Add option for hubs to require specific client versions

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/hubmagic/PingManager.java
+++ b/src/main/java/com/imaginarycode/minecraft/hubmagic/PingManager.java
@@ -86,6 +86,9 @@ public class PingManager {
             if (entry.getValue().getPlayerCount() >= entry.getValue().getPlayerMax())
                 continue;
 
+            if (!HubMagic.getPlugin().checkClientVersion(entry.getKey(), player))
+                continue;
+
             if (player.getServer() != null && player.getServer().getInfo().equals(entry.getKey()))
                 continue;
 
@@ -104,6 +107,9 @@ public class PingManager {
             if (entry.getValue().getPlayerCount() >= entry.getValue().getPlayerMax())
                 continue;
 
+            if (!HubMagic.getPlugin().checkClientVersion(entry.getKey(), player))
+                continue;
+
             if (player.getServer() != null && player.getServer().getInfo().equals(entry.getKey()))
                 continue;
 
@@ -119,6 +125,6 @@ public class PingManager {
         PingResult ping = pings.get(serverInfo);
 
         return ping != null && !ping.isDown() && ping.getPlayerCount() < ping.getPlayerMax() &&
-                (player.getServer() == null || !player.getServer().getInfo().equals(serverInfo));
+                (player.getServer() == null || !player.getServer().getInfo().equals(serverInfo)) && HubMagic.getPlugin().checkClientVersion(serverInfo, player);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,11 @@ servers:
 - Hub2
 - Hub3
 
+# Specify the required client version for each Hub, leave as an empty array [] to use BungeeCords' defaults.
+# The values are parsed as Integers and can be obtained from http://wiki.vg/Protocol_version_numbers
+required-client-versions:
+  Hub1: []
+
 # Specify the duration (in seconds) between server pings.
 # This is used in selecting servers for the "lowest", "firstavailable", "random" and "sequential" modes.
 # 3 seconds is the default. If you have more than 10-12 hubs this number may need increasing.


### PR DESCRIPTION
For example, it is useful when you want players joining from 1.8 servers to be sent to a 1.8 Hub that allows you to connect to all of the 1.8 servers, and vice verse for 1.9.